### PR TITLE
KEYS: close race between key lookup and freeing

### DIFF
--- a/security/keys/gc.c
+++ b/security/keys/gc.c
@@ -188,11 +188,11 @@ static noinline void key_gc_unused_key(struct key *key)
 	if (test_bit(KEY_FLAG_INSTANTIATED, &key->flags))
 		atomic_dec(&key->user->nikeys);
 
-	key_user_put(key->user);
-
 	/* now throw away the key memory */
 	if (key->type->destroy)
 		key->type->destroy(key);
+
+	key_user_put(key->user);
 
 	kfree(key->description);
 


### PR DESCRIPTION
When a key is being garbage collected, it's key->user would get put before
the ->destroy() callback is called, where the key is removed from it's
respective tracking structures.

This leaves a key hanging in a semi-invalid state which leaves a window open
for a different task to try an access key->user. An example is
find_keyring_by_name() which would dereference key->user for a key that is
in the process of being garbage collected (where key->user was freed but
->destroy() wasn't called yet - so it's still present in the linked list).

This would cause either a panic, or corrupt memory.

Change-Id: Ic74246dc2dcc593f04f71063e3301e7356d588b7
Signed-off-by: Sasha Levin sasha.levin@oracle.com
